### PR TITLE
19 add base query pipeline

### DIFF
--- a/CSharpBackend/Files/ControllerClassFile.cs
+++ b/CSharpBackend/Files/ControllerClassFile.cs
@@ -7,10 +7,10 @@ namespace CSharpBackend.Files
     {
         public const string CLASS_NAME_SUFFIX = "Controller";
 
-        public ControllerClassFile(string serviceName, SwarmDir dir)
+        public ControllerClassFile(string solutionName, string serviceName, SwarmDir dir)
             : base(serviceName + CLASS_NAME_SUFFIX, dir)
         {
-            AppendLine(ControllerTemplate.Render(serviceName, serviceName + CLASS_NAME_SUFFIX));
+            AppendLine(ControllerTemplate.Render(solutionName, serviceName, serviceName + CLASS_NAME_SUFFIX));
         }
     }
 }

--- a/CSharpBackend/Files/QueryMapperActorFile.cs
+++ b/CSharpBackend/Files/QueryMapperActorFile.cs
@@ -1,0 +1,46 @@
+using MicroSwarm.FileSystem;
+using MicroSwarm.Templates;
+using Mss;
+using System.Diagnostics;
+
+namespace CSharpBackend.Files
+{
+    public class QueryMapperActorFile : CSharpFile
+    {
+        public const string CLASS_NAME = "QueryMapperActor";
+        public QueryMapperActorFile(string solutionName, MssService service, SwarmDir dir)
+            : base(CLASS_NAME, dir)
+        {
+            AppendLine(QueryMapperActorTemplate.RenderHeader(solutionName, service.Name));
+            Indentation = METHOD_CONTENT_INDENT;
+            Indent(4);
+
+            foreach (var aggField in service.AggregateFields)
+            {
+                if (aggField.Mapping is MssAggregateFieldMappingDirect direct)
+                {
+                    Append(aggField.Field.Name + " = ");
+                    Append("entity.");
+                    if (direct.Mapping.Count == 1)
+                    {
+                        AppendLine(direct.Mapping[0].Item2.Name + ",");
+                    }
+                    else
+                    {
+                        Debug.Assert(direct.Mapping.Count == 2);
+                        Append(direct.Mapping[1].Item1.Name + ".");
+                        Append(direct.Mapping[1].Item2.Name + ",");
+                    }
+                }
+                else
+                {
+                    // TODO: fill in for other mappings, handling to many
+                    //throw new NotImplementedException();
+                }
+            }
+
+            ClearIndentation();
+            AppendLine(QueryMapperActorTemplate.RenderFooter());
+        }
+    }
+}

--- a/CSharpBackend/Files/QueryRootFilterFile.cs
+++ b/CSharpBackend/Files/QueryRootFilterFile.cs
@@ -1,0 +1,20 @@
+using CSharpBackend.Projects;
+using MicroSwarm.FileSystem;
+using MicroSwarm.Templates;
+
+namespace CSharpBackend.Files
+{
+    public class QueryRootFilterFile : CSharpFile
+    {
+        public QueryRootFilterFile(string solutionName, string serviceName, SwarmDir dir, bool usesValues)
+            : base(serviceName + "Filter", dir)
+        {
+            if (usesValues)
+            {
+                AppendLine(UsingTemplate.Render(ValueTypeProject.ProjectName));
+                AppendLine();
+            }
+            Append(QueryFilterTemplate.Render(solutionName, serviceName));
+        }
+    }
+}

--- a/CSharpBackend/Files/RepositoryActorFile.cs
+++ b/CSharpBackend/Files/RepositoryActorFile.cs
@@ -1,0 +1,46 @@
+using MicroSwarm.FileSystem;
+using MicroSwarm.Templates;
+using Mss;
+using Mss.Types;
+using System.Diagnostics;
+
+namespace CSharpBackend.Files
+{
+    public class RepositoryActorFile : CSharpFile
+    {
+        public const string CLASS_NAME = "RepositoryActor";
+
+        public RepositoryActorFile(string solutionName, MssService service, SwarmDir dir)
+            : base(CLASS_NAME, dir)
+        {
+            Append(RepositoryActorTemplate.RenderHeader(solutionName, service.Name));
+            Indentation = METHOD_CONTENT_INDENT;
+            Indent(4);
+
+            Append(RepositoryActorTemplate.RenderSetHeader(service.Name));
+            foreach (var field in service.Database.Root.Fields)
+            {
+                if (field.Type is MssKeyType key && key.ToString() == "FK")
+                {
+                    var rels = service.Database.Relations.Where(r => r.ContainsField(field)).ToList();
+                    Debug.Assert(rels.Count == 1);
+
+                    var toField = rels[0].GetOppositeField(field)!;
+                    var toEntity = rels[0].GetOppositeEntity(service.Database.Root)!;
+                    var fromRel = rels[0].GetRelation(field)!;
+                    var toRel = rels[0].GetRelation(toField)!;
+
+                    string toEntityName = MssEntity.GetName(toEntity, service.Name);
+                    Debug.Assert(field.Type.IsPkFkPair(toField.Type));
+
+                    Append(".Include(r => r." + toEntityName + ")");
+                    // Todo: include toEntity's relations if they do not point back at the root
+                }
+            }
+            AppendLine(RepositoryActorTemplate.RenderSetFooter());
+
+            ClearIndentation();
+            AppendLine(RepositoryActorTemplate.RenderFooter());
+        }
+    }
+}

--- a/CSharpBackend/Files/StartupClassFile.cs
+++ b/CSharpBackend/Files/StartupClassFile.cs
@@ -7,8 +7,13 @@ namespace CSharpBackend.Files
     {
         public const string CLASS_NAME = "Startup";
 
-        public StartupClassFile(string serviceName, SwarmDir dir) : base(CLASS_NAME, dir)
+        public StartupClassFile(string solutionName, string serviceName, SwarmDir dir) : base(CLASS_NAME, dir)
         {
+            AppendLine(UsingTemplate.Render("Microsoft.EntityFrameworkCore"));
+            AppendLine(UsingTemplate.Render(serviceName + ".Actors"));
+            AppendLine(UsingTemplate.Render(solutionName + "Core.Actors"));
+            AppendLine();
+
             AppendLine(StartupTemplate.RenderHeader(serviceName, CLASS_NAME));
             AppendLine();
 

--- a/CSharpBackend/Projects/CoreProject.cs
+++ b/CSharpBackend/Projects/CoreProject.cs
@@ -1,4 +1,6 @@
+using CSharpBackend.Files;
 using MicroSwarm.FileSystem;
+using MicroSwarm.Templates;
 
 namespace CSharpBackend.Projects
 {
@@ -8,6 +10,19 @@ namespace CSharpBackend.Projects
 
         public CoreProject(string serviceName, SwarmDir solutionDir) : base(serviceName + Suffix, solutionDir)
         {
+            // add filter classes
+            var filterDir = Dir.CreateSub("Filtering", true);
+            AddFile(new CSharpFile("QueryFilter", filterDir, QueryFilterBaseClassTemplate.Render(serviceName)));
+
+            // add actor classes
+            var actorDir = Dir.CreateSub("Actors", true);
+            AddFile(new CSharpFile("IActorResult", actorDir, IActorResultTemplate.Render(serviceName)));
+            AddFile(new CSharpFile("IActorBridge", actorDir, IActorBridgeTemplate.Render(serviceName)));
+            AddFile(new CSharpFile("ActorService", actorDir, ActorServiceTemplate.Render(serviceName)));
+
+            AddPackageReference("Microsoft.Extensions.Hosting", "8.0.0");
+            AddPackageReference("Akka", "1.5.14");
+            AddPackageReference("Akka.DependencyInjection", "1.5.14");
         }
     }
 }

--- a/Templates/ActorTemplates/ActorServiceTemplate.cs
+++ b/Templates/ActorTemplates/ActorServiceTemplate.cs
@@ -1,0 +1,73 @@
+namespace MicroSwarm.Templates
+{
+    public static class ActorServiceTemplate
+    {
+        public static string Render(string serviceName)
+        {
+            return
+$$"""
+using System.Diagnostics;
+using Akka.Actor;
+using Akka.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace {{serviceName}}Core.Actors
+{
+    public class ActorService<A>(IServiceProvider serviceProvider, IHostApplicationLifetime appLifetime, IConfiguration configuration)
+        : IHostedService, IActorBridge
+        where A : ReceiveActor, new()
+    {
+        private ActorSystem? _actorSystem = null;
+        private IActorRef? _actorRef = null;
+
+        private readonly IServiceProvider _serviceProvider = serviceProvider;
+        private readonly IHostApplicationLifetime _appLifetime = appLifetime;
+        private readonly IConfiguration _configuration = configuration;
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            var bootstrap = BootstrapSetup.Create();
+
+            // enable DI support inside this ActorSystem, if needed
+            var diSetup = DependencyResolverSetup.Create(_serviceProvider);
+
+            // merge setups
+            var actorSystemSetup = bootstrap.And(diSetup);
+
+            // start the actor system
+            _actorSystem = ActorSystem.Create("{{serviceName}}", actorSystemSetup);
+            _actorRef = _actorSystem.ActorOf<A>("controller-actor");
+
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+            _actorSystem.WhenTerminated.ContinueWith(_ =>
+            {
+                _appLifetime.StopApplication();
+            });
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+
+            await Task.CompletedTask;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            await CoordinatedShutdown.Get(_actorSystem).Run(CoordinatedShutdown.ClrExitReason.Instance);
+        }
+
+        public void Tell(object message)
+        {
+            Debug.Assert(_actorRef != null);
+            _actorRef.Tell(message);
+        }
+
+        public Task<IActorResult> Ask(object message)
+        {
+            Debug.Assert(_actorRef != null);
+            return _actorRef.Ask<IActorResult>(message);
+        }
+    }
+}
+""";
+        }
+    }
+}

--- a/Templates/ActorTemplates/CmdActorTemplate.cs
+++ b/Templates/ActorTemplates/CmdActorTemplate.cs
@@ -1,0 +1,29 @@
+namespace MicroSwarm.Templates
+{
+    public static class CmdActorTemplate
+    {
+        public static string Render(string solutionName, string serviceName)
+        {
+            return
+$$"""
+using System.Text.Json;
+using Akka.Actor;
+using {{solutionName}}Core.Actors;
+
+namespace {{serviceName}}.Actors
+{
+    public class CmdActor : ReceiveActor
+    {
+        public CmdActor()
+        {
+            Receive<JsonDocument>(cmd =>
+            {
+                Sender.Tell(IActorResult.BadResult("{{serviceName}} can't handle this cmd: \"" + cmd.RootElement.ToString() + "\""), Self);
+            });
+        }
+    }
+}
+""";
+        }
+    }
+}

--- a/Templates/ActorTemplates/ControllerActorTemplate.cs
+++ b/Templates/ActorTemplates/ControllerActorTemplate.cs
@@ -1,0 +1,40 @@
+namespace MicroSwarm.Templates
+{
+    public static class ControllerActorTemplate
+    {
+        public static string Render(string solutionName, string serviceName)
+        {
+            return
+$$"""
+using System.Text.Json;
+using Akka.Actor;
+using {{solutionName}}Core.Actors;
+
+namespace {{serviceName}}.Actors
+{
+    public class {{serviceName}}ControllerActor : ReceiveActor
+    {
+        private readonly IActorRef _queryActor;
+        private readonly IActorRef _cmdActor;
+
+        public {{serviceName}}ControllerActor()
+        {
+            _queryActor = Context.ActorOf(Props.Create<QueryActor>(), "query-actor");
+            _cmdActor = Context.ActorOf(Props.Create<CmdActor>(), "cmd-actor");
+
+            Receive<string>(filterStr =>
+            {
+                Sender.Tell(_queryActor.Ask<IActorResult>(filterStr).Result);
+            });
+
+            Receive<JsonDocument>(cmd =>
+            {
+                Sender.Tell(_cmdActor.Ask<IActorResult>(cmd).Result);
+            });
+        }
+    }
+}
+""";
+        }
+    }
+}

--- a/Templates/ActorTemplates/IActorBridgeTemplate.cs
+++ b/Templates/ActorTemplates/IActorBridgeTemplate.cs
@@ -1,0 +1,20 @@
+namespace MicroSwarm.Templates
+{
+    public static class IActorBridgeTemplate
+    {
+        public static string Render(string serviceName)
+        {
+            return
+$$"""
+namespace {{serviceName}}Core.Actors
+{
+    public interface IActorBridge
+    {
+        void Tell(object message);
+        Task<IActorResult> Ask(object message);
+    }
+}
+""";
+        }
+    }
+}

--- a/Templates/ActorTemplates/IActorResultTemplate.cs
+++ b/Templates/ActorTemplates/IActorResultTemplate.cs
@@ -1,0 +1,35 @@
+namespace MicroSwarm.Templates
+{
+    public static class IActorResultTemplate
+    {
+        public static string Render(string serviceName)
+        {
+            return
+$$"""
+namespace {{serviceName}}Core.Actors
+{
+    public interface IActorResult
+    {
+        public bool Ok { get; set; }
+        public string Value { get; set; }
+        public static IActorResult OkResult(string value)
+        {
+            return new ActorResult { Ok = true, Value = value };
+        }
+
+        public static IActorResult BadResult(string value)
+        {
+            return new ActorResult { Ok = false, Value = value };
+        }
+    }
+
+    public class ActorResult : IActorResult
+    {
+        public bool Ok { get; set; } = true;
+        public string Value { get; set; } = "";
+    }
+}
+""";
+        }
+    }
+}

--- a/Templates/ActorTemplates/Query/QueryActorTemplate.cs
+++ b/Templates/ActorTemplates/Query/QueryActorTemplate.cs
@@ -1,0 +1,33 @@
+namespace MicroSwarm.Templates
+{
+    public static class QueryActorTemplate
+    {
+        public static string Render(string solutionName, string serviceName)
+        {
+            return
+$$"""
+using Akka.Actor;
+using {{solutionName}}Core.Actors;
+
+namespace {{serviceName}}.Actors
+{
+    public class QueryActor : ReceiveActor
+    {
+        private readonly IActorRef _filterCreator;
+
+        public QueryActor()
+        {
+            _filterCreator = Context.ActorOf(Props.Create<FilterCreatorActor>(), "filter-creator");
+
+            Receive<string>(filterStr =>
+            {
+                var result = _filterCreator.Ask<IActorResult>(filterStr).Result;
+                Sender.Tell(result);
+            });
+        }
+    }
+}
+""";
+        }
+    }
+}

--- a/Templates/ActorTemplates/Query/QueryFilterCreatorActorTemplate.cs
+++ b/Templates/ActorTemplates/Query/QueryFilterCreatorActorTemplate.cs
@@ -1,0 +1,47 @@
+namespace MicroSwarm.Templates
+{
+    public static class QueryFilterCreatorActorTemplate
+    {
+        public static string Render(string solutionName, string serviceName)
+        {
+            return
+$$"""
+using Akka.Actor;
+using Akka.DependencyInjection;
+using {{solutionName}}Core.Actors;
+
+namespace {{serviceName}}.Actors
+{
+    public class FilterCreatorActor : ReceiveActor
+    {
+        private readonly IActorRef _repositoryActor;
+        public FilterCreatorActor()
+        {
+            var repoProps = DependencyResolver.For(Context.System).Props<RepositoryActor>();
+            _repositoryActor = Context.ActorOf(repoProps, "repository-actor");
+
+            Receive<string>(filterStr =>
+            {
+                try
+                {
+                    var filter = new {{serviceName}}Filter().FromJson(filterStr).CreateFilter();
+                    var result = _repositoryActor.Ask<IActorResult>(filter).Result;
+                    Sender.Tell(result);
+                }
+                catch (Exception e)
+                {
+                    // get the innermost exception
+                    while (e.InnerException != null)
+                    {
+                        e = e.InnerException;
+                    }
+                    Sender.Tell(IActorResult.BadResult(e.Message));
+                }
+            });
+        }
+    }
+}
+""";
+        }
+    }
+}

--- a/Templates/ActorTemplates/Query/QueryMapperActorTemplate.cs
+++ b/Templates/ActorTemplates/Query/QueryMapperActorTemplate.cs
@@ -1,0 +1,48 @@
+namespace MicroSwarm.Templates
+{
+    public static class QueryMapperActorTemplate
+    {
+        public static string RenderHeader(string solutionName, string serviceName)
+        {
+            return
+$$"""
+using Akka.Actor;
+using {{serviceName}}.Entities;
+using {{solutionName}}Core.Actors;
+
+namespace {{serviceName}}.Actors
+{
+    public class QueryMapperActor : ReceiveActor
+    {
+        private readonly IActorRef _serializeActor;
+
+        public QueryMapperActor()
+        {
+            _serializeActor = Context.ActorOf(Props.Create<QuerySerializeActor>(), "serialize-actor");
+
+            Receive<IEnumerable<{{serviceName}}Root>>(entities =>
+            {
+                List<{{serviceName}}Aggregate> aggregates = [];
+                foreach (var entity in entities)
+                {
+                    aggregates.Add(new {{serviceName}}Aggregate
+                    {
+""";
+        }
+
+        public static string RenderFooter()
+        {
+            return
+"""
+                    });
+                }
+                var result = _serializeActor.Ask<IActorResult>(aggregates).Result;
+                Sender.Tell(result);
+            });
+        }
+    }
+}
+""";
+        }
+    }
+}

--- a/Templates/ActorTemplates/Query/QuerySerializeActorTemplate.cs
+++ b/Templates/ActorTemplates/Query/QuerySerializeActorTemplate.cs
@@ -1,0 +1,42 @@
+namespace MicroSwarm.Templates
+{
+    public static class QuerySerializeActorTemplate
+    {
+        public static string Render(string solutionName, string serviceName)
+        {
+            return
+$$"""
+using System.Text.Json;
+using Akka.Actor;
+using {{solutionName}}Core.Actors;
+
+namespace {{serviceName}}.Actors
+{
+    public class QuerySerializeActor : ReceiveActor
+    {
+        public QuerySerializeActor()
+        {
+            Receive<IEnumerable<{{serviceName}}Aggregate>>(aggregates =>
+            {
+                try
+                {
+                    var result = JsonSerializer.Serialize(aggregates);
+                    Sender.Tell(IActorResult.OkResult(result));
+                }
+                catch (Exception e)
+                {
+                    // get the innermost exception
+                    while (e.InnerException != null)
+                    {
+                        e = e.InnerException;
+                    }
+                    Sender.Tell(IActorResult.BadResult(e.Message));
+                }
+            });
+        }
+    }
+}
+""";
+        }
+    }
+}

--- a/Templates/ActorTemplates/RepositoryActorTemplate.cs
+++ b/Templates/ActorTemplates/RepositoryActorTemplate.cs
@@ -1,0 +1,68 @@
+namespace MicroSwarm.Templates
+{
+    public static class RepositoryActorTemplate
+    {
+        public static string RenderHeader(string solutionName, string serviceName)
+        {
+            return
+$$"""
+using Akka.Actor;
+using {{serviceName}}.Entities;
+using Microsoft.EntityFrameworkCore;
+using {{solutionName}}Core.Actors;
+
+namespace {{serviceName}}.Actors
+{
+    public class RepositoryActor : ReceiveActor
+    {
+        private readonly {{serviceName}}DbContext _context;
+
+        private readonly IActorRef _queryMapper;
+
+        public RepositoryActor({{serviceName}}DbContext context)
+        {
+            _context = context;
+
+            _queryMapper = Context.ActorOf(Props.Create<QueryMapperActor>(), "query-mapper");
+
+            Receive<Func<{{serviceName}}Root, bool>>(filter =>
+            {
+                try
+                {
+""";
+        }
+
+        public static string RenderSetHeader(string serviceName)
+        {
+            return $"var entities = _context.Set<{serviceName}Root>().AsNoTracking()";
+        }
+
+        public static string RenderSetFooter()
+        {
+            return ".Where(filter);";
+        }
+
+        public static string RenderFooter()
+        {
+            return
+"""
+                    var result = _queryMapper.Ask<IActorResult>(entities).Result;
+                    Sender.Tell(result);
+                }
+                catch (Exception e)
+                {
+                    // get the innermost exception
+                    while (e.InnerException != null)
+                    {
+                        e = e.InnerException;
+                    }
+                    Sender.Tell(IActorResult.BadResult(e.Message));
+                }
+            });
+        }
+    }
+}
+""";
+        }
+    }
+}

--- a/Templates/ControllerTemplate.cs
+++ b/Templates/ControllerTemplate.cs
@@ -28,11 +28,7 @@ namespace {{serviceName}}
         public async Task<IActionResult> Cmd([FromBody][Required] JsonDocument jsonData)
         {
             var result = await _bridge.Ask(jsonData);
-            return result.Ok switch
-            {
-                true => Ok(result.Value),
-                false => BadRequest(result.Value),
-            };
+            return ToActionResult(result);
         }
 
         /// <summary>
@@ -46,6 +42,11 @@ namespace {{serviceName}}
         public async Task<IActionResult> Query([FromQuery] string filter)
         {
             var result = await _bridge.Ask(filter);
+            return ToActionResult(result);
+        }
+
+        private static IActionResult ToActionResult(IActorResult result)
+        {
             return result.Ok switch
             {
                 true => Ok(result.Value),

--- a/Templates/EntityTemplate.cs
+++ b/Templates/EntityTemplate.cs
@@ -10,6 +10,7 @@ namespace {{namespaceName}}
 {
     public class {{entityName}}
     {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
 """;
         }
 
@@ -17,6 +18,7 @@ namespace {{namespaceName}}
         {
             return
 """
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
     }
 }
 """;

--- a/Templates/QueryFilterBaseClassTemplate.cs
+++ b/Templates/QueryFilterBaseClassTemplate.cs
@@ -1,0 +1,22 @@
+namespace MicroSwarm.Templates
+{
+    public static class QueryFilterBaseClassTemplate
+    {
+        public static string Render(string serviceName)
+        {
+            return
+$$"""
+namespace {{serviceName}}Core.Filtering
+{
+    public abstract class QueryFilter<T>
+    {
+        public QueryFilter() { }
+        public abstract QueryFilter<T> FromJson(string jsonString);
+
+        public virtual Func<T, bool> CreateFilter() => (t) => true;
+    }
+}
+""";
+        }
+    }
+}

--- a/Templates/QueryFilterTemplate.cs
+++ b/Templates/QueryFilterTemplate.cs
@@ -1,0 +1,25 @@
+namespace MicroSwarm.Templates
+{
+    public static class QueryFilterTemplate
+    {
+        public static string Render(string solutionName, string serviceName)
+        {
+            return
+$$"""
+using {{serviceName}}.Entities;
+using {{solutionName}}Core.Filtering;
+
+namespace {{serviceName}}
+{
+    public class {{serviceName}}Filter : QueryFilter<{{serviceName}}Root>
+    {
+        public override QueryFilter<{{serviceName}}Root> FromJson(string jsonString)
+        {
+            return this;
+        }
+    }
+}
+""";
+        }
+    }
+}

--- a/Templates/StartupTemplate.cs
+++ b/Templates/StartupTemplate.cs
@@ -32,6 +32,16 @@ public virtual void ConfigureServices(IServiceCollection services)
     services.AddControllers();
     services.AddEndpointsApiExplorer();
     services.AddSwaggerGen();
+
+    // add actors
+    services.AddSingleton<IActorBridge, ActorService<{{serviceName}}ControllerActor>>();
+    services.AddHostedService(sp => (ActorService<{{serviceName}}ControllerActor>)sp.GetRequiredService<IActorBridge>());
+
+    // add db
+    services.AddDbContext<{{serviceName}}DbContext>(options =>
+    {
+        options.UseInMemoryDatabase("{{serviceName}}");
+    }, contextLifetime: ServiceLifetime.Transient, optionsLifetime: ServiceLifetime.Transient);
 }
 """;
         }

--- a/Templates/ValueClassTemplate.cs
+++ b/Templates/ValueClassTemplate.cs
@@ -22,10 +22,12 @@ namespace {{namespaceName}}
 {
     public class {{className}}
     {
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
         public {{fieldTypeName}} {{fieldName}} { get; set; }
 
         public {{className}}() { }
         public {{className}}({{fieldTypeName}} value) => {{fieldName}} = value;
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
     }
 }
 """;


### PR DESCRIPTION
- Added a basic query pipeline using the actor pattern from Akka
- Does not fully map the root to aggregate, need to enfore only built-in or external key types for aggregate
- Always using the trivial filter `(entity) => true` so far. Will add filtering later, but not much point yet when we still can't add anything to the database anyway.